### PR TITLE
Include tests in sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,7 @@
 include LICENSE README.md
 
+recursive-include tests *
+
 global-exclude .git*
 global-exclude *.pyo
 global-exclude *.pyc


### PR DESCRIPTION
This lets downstream run the unit tests.  This is particularly important for Linux rpm packagers.